### PR TITLE
Updated troubleshoot guide

### DIFF
--- a/src/commands/Vanced/troubleshooting.ts
+++ b/src/commands/Vanced/troubleshooting.ts
@@ -96,7 +96,7 @@ const callback = async (msg: Message, args: string[]) => {
 
 export const command: Command = {
 	aliases: ['troubleshoot', 'ts'],
-	description: 'Troubleshoot Vanced issues. For your own issues, consult your therapist ;)',
+	description: 'Troubleshoot Vanced issues. For your own issues, consult your therapist ;).',
 	usage: '[Page]',
 	devOnly: false,
 	guildOnly: false,

--- a/src/commands/Vanced/troubleshooting.ts
+++ b/src/commands/Vanced/troubleshooting.ts
@@ -16,15 +16,6 @@ const pages = [
 		),
 
 	embed()
-		.setTitle('Old devices')
-		.setDescription(
-			stripIndents`
-				If you have an old device, it might be using the arm (32bit) kernel architecture instead of arm64 (64bit)
-				If you get the error \`This app is incompatible with your device\`, this is the case.
-				Download the legacy version instead and try again.`
-		),
-
-	embed()
 		.setTitle('Dark Splashscreen')
 		.setDescription(
 			"To get a dark loading screen, enable dark theme in your system settings. If you don't have this setting, find an app that does it for you on the Google Play Store"
@@ -53,9 +44,11 @@ const pages = [
 		),
 
 	embed()
-		.setTitle('Vanced broken after password change')
+		.setTitle('No connection/Vanced broken after password change')
 		.setDescription(
-			'Go to `Device Settings > Account`, select the account with the <:oldgacc:679434987560370188> logo and remove it. Then simply add it back via Vanced.'
+			stripIndents`
+			Go to \`Device Settings > Accounts\`, select the account with the <:vancedmicrog:739533000609628191> (or <:oldgacc:679434987560370188>) logo and remove it. Then simply add it back via Vanced.
+			If the account isnt there then simply reinstall Vanced MicroG via the manager`
 		),
 
 	embed()
@@ -81,15 +74,11 @@ const pages = [
 		),
 
 	embed()
-		.setThumbnail('https://i.imgur.com/TXiSaeI.png')
-		.setTitle('Home Ads')
+		.setTitle('YouTube Vanced is draining more battery than stock YouTube')
 		.setDescription(
 			stripIndents`
-				You might be getting ads on your home feed.
-				No, these aren't placed there by the Vanced Devs to make a quick buck. Youtube somehow detects that Vanced blocks ads and thus gives you extra ads which are based on your region.
-				This will be fixed in the next release!
-
-				|| Tip: To get this update early, become a tester or boost the server ||`
+				This might be caused by the current method used to hide home ads, to fix go to \`Vanced Settings > Ad settings > And enable home ads\`
+				A better method to hide home ads might be available in a future update`
 		),
 
 	embed()


### PR DESCRIPTION
The old devices troubleshoot is no longer needed since the manager automatically decides which one to install, I also updated the home ads troubleshoot since those are now fixed but instead cause the battery drain issue in some devices. I also updated the password change ts to include "no connection" in the title so people dont dismiss it thinking that isnt their issue, also updated account logo to the new vanced microg one